### PR TITLE
Use correct UTF-8 locale.

### DIFF
--- a/preseed-skolelinux.cfg
+++ b/preseed-skolelinux.cfg
@@ -2,7 +2,7 @@
 #### Contents of the preconfiguration file (for bookworm)
 ### Localization
 # Preseeding only locale sets language, country and locale.
-d-i debian-installer/locale string nb_NO
+d-i debian-installer/locale string nb_NO.UTF-8
 
 # The values can also be preseeded individually for greater flexibility.
 #d-i debian-installer/language string en


### PR DESCRIPTION
The nb_NO locale uses ISO-8859-1, while these days UTF-8 is more useful.